### PR TITLE
[feat.] simple implementation of ELink RefList & OSS AuthPlugin:

### DIFF
--- a/src/overlaybd/CMakeLists.txt
+++ b/src/overlaybd/CMakeLists.txt
@@ -6,6 +6,8 @@ add_subdirectory(tar)
 add_subdirectory(gzip)
 add_subdirectory(gzindex)
 add_subdirectory(stream_convertor)
+add_subdirectory(elink)
+
 
 add_library(overlaybd_lib INTERFACE)
 target_include_directories(overlaybd_lib INTERFACE
@@ -20,4 +22,5 @@ target_link_libraries(overlaybd_lib INTERFACE
     tar_lib
     gzip_lib
     gzindex_lib
+    elink_lib
 )

--- a/src/overlaybd/elink/CMakeLists.txt
+++ b/src/overlaybd/elink/CMakeLists.txt
@@ -1,0 +1,14 @@
+file(GLOB SOURCE_ELINK "*.cpp")
+
+add_library(elink_lib STATIC ${SOURCE_ELINK})
+target_include_directories(elink_lib PUBLIC
+    ${PHOTON_INCLUDE_DIR}
+)
+target_link_libraries(elink_lib
+    photon_static
+    yaml-cpp
+)
+
+if(BUILD_TESTING)
+   add_subdirectory(test)
+endif()

--- a/src/overlaybd/elink/config.h
+++ b/src/overlaybd/elink/config.h
@@ -1,0 +1,32 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#pragma once
+
+#include <string>
+#include <vector>
+#include "../stream_convertor/config_utils.h"
+
+namespace App {
+
+struct OssCredential : public App::ConfigGroup {
+    APPCFG_CLASS
+    APPCFG_PARA(accessKeyID, std::string, "");
+    APPCFG_PARA(accessKeySecret, std::string, "");
+};
+
+
+
+}

--- a/src/overlaybd/elink/def.h
+++ b/src/overlaybd/elink/def.h
@@ -1,0 +1,77 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#pragma once
+
+#include <photon/fs/filesystem.h>
+#include <string.h>
+#include <assert.h>
+#include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/common/estring.h>
+#include <photon/common/string_view.h>
+#include <unordered_map>
+#include "elink.h"
+
+namespace ELink {
+
+static const int RAW_ALIGNED_SIZE = 1024;
+
+struct TargetObject {
+    std::string_view m_endpoint;
+    std::string_view m_bucket_name;
+    std::string_view source;
+    std::string_view etag;
+    size_t filesize = 0;
+
+    TargetObject(std::string_view endpoint, std::string_view bucket_name, const char* raw_data, size_t size) : 
+        m_endpoint(endpoint), m_bucket_name(bucket_name) {
+        assert(size == RAW_ALIGNED_SIZE);
+        auto p = raw_data;
+        filesize = ((size_t*)raw_data)[0];
+        p += sizeof(filesize);
+        source = std::string_view(p, strlen(p));
+        p += source.size() + 1;
+        etag = std::string_view(p, strlen(p));
+        LOG_DEBUG("parse target object. {source :` , size: `, etag: `}", source, filesize, etag);
+    }
+
+    estring remote_url() const {
+        estring url;
+        url.append("https://");
+        url.append(m_bucket_name);
+        url.append(".");
+        url.append(m_endpoint);
+        url.append(source);
+        LOG_DEBUG("remote url: `", url);
+        return url;
+    }
+};
+
+class ICredentialClient {
+public:
+    virtual std::unordered_map<estring, estring> access_key(std::string_view url) = 0;
+    virtual ~ICredentialClient() {};
+};
+
+class IAuthPlugin {
+public:
+    // virtual std::unordered_map<estring, estring> get_signed_info(const TargetObject &remote_url, std::string_view etag, size_t filesize) = 0;
+    virtual photon::fs::IFile* get_signed_object(const TargetObject &t) = 0;
+    virtual ~IAuthPlugin(){};
+};
+
+
+}

--- a/src/overlaybd/elink/def.h
+++ b/src/overlaybd/elink/def.h
@@ -18,8 +18,7 @@
 #include <photon/fs/filesystem.h>
 #include <string.h>
 #include <assert.h>
-#include <photon/common/alog.h>
-#include <photon/common/alog-stdstring.h>
+
 #include <photon/common/estring.h>
 #include <photon/common/string_view.h>
 #include <unordered_map>
@@ -27,38 +26,8 @@
 
 namespace ELink {
 
-static const int RAW_ALIGNED_SIZE = 1024;
 
-struct TargetObject {
-    std::string_view m_endpoint;
-    std::string_view m_bucket_name;
-    std::string_view source;
-    std::string_view etag;
-    size_t filesize = 0;
 
-    TargetObject(std::string_view endpoint, std::string_view bucket_name, const char* raw_data, size_t size) : 
-        m_endpoint(endpoint), m_bucket_name(bucket_name) {
-        assert(size == RAW_ALIGNED_SIZE);
-        auto p = raw_data;
-        filesize = ((size_t*)raw_data)[0];
-        p += sizeof(filesize);
-        source = std::string_view(p, strlen(p));
-        p += source.size() + 1;
-        etag = std::string_view(p, strlen(p));
-        LOG_DEBUG("parse target object. {source :` , size: `, etag: `}", source, filesize, etag);
-    }
-
-    estring remote_url() const {
-        estring url;
-        url.append("https://");
-        url.append(m_bucket_name);
-        url.append(".");
-        url.append(m_endpoint);
-        url.append(source);
-        LOG_DEBUG("remote url: `", url);
-        return url;
-    }
-};
 
 class ICredentialClient {
 public:
@@ -69,7 +38,7 @@ public:
 class IAuthPlugin {
 public:
     // virtual std::unordered_map<estring, estring> get_signed_info(const TargetObject &remote_url, std::string_view etag, size_t filesize) = 0;
-    virtual photon::fs::IFile* get_signed_object(const TargetObject &t) = 0;
+    virtual photon::fs::IFile* get_signed_object(const ELinkObject &t) = 0;
     virtual ~IAuthPlugin(){};
 };
 

--- a/src/overlaybd/elink/elink.h
+++ b/src/overlaybd/elink/elink.h
@@ -1,0 +1,50 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <stdlib.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <photon/common/estring.h>
+#include <photon/fs/filesystem.h>
+
+namespace ELink{
+
+
+struct TargetObject;
+
+class ICredentialClient; 
+class IAuthPlugin;
+
+enum class AuthPluginType {
+    AliyunOSS
+};
+
+class IReferenceList {
+public:
+    virtual photon::fs::IFile* get_remote_target(off_t target_index = -1) = 0;
+    virtual ~IReferenceList();
+};
+
+IReferenceList *create_reference_list(photon::fs::IFile* file, std::string_view bucket_name, IAuthPlugin *auth);
+
+ICredentialClient *create_simple_cred_client(const char *fn);
+IAuthPlugin *create_auth_plugin(ICredentialClient *cred, AuthPluginType type);
+
+photon::fs::IFile *open_elink_file(IReferenceList *reflist);
+
+}

--- a/src/overlaybd/elink/elink.h
+++ b/src/overlaybd/elink/elink.h
@@ -21,11 +21,14 @@
 #include <stdio.h>
 #include <photon/common/estring.h>
 #include <photon/fs/filesystem.h>
+#include <string_view>
+#include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
 
 namespace ELink{
 
 
-struct TargetObject;
+struct ELinkObject;
 
 class ICredentialClient; 
 class IAuthPlugin;
@@ -34,17 +37,70 @@ enum class AuthPluginType {
     AliyunOSS
 };
 
+static const int ALIGNMENT_BLK = 4096;
+static const int RAW_ALIGNED_SIZE = 1024;
+
+
+struct ELinkObject {
+    estring endpoint;
+    estring bucket_name;
+    estring source;
+    estring mount_path;
+    estring etag;
+    size_t filesize = 0;
+
+    ELinkObject(){};
+
+    ELinkObject(std::string_view endpoint, std::string_view bucket_name, const char* raw_data, size_t size) : 
+        endpoint(endpoint), bucket_name(bucket_name) {
+        assert(size == RAW_ALIGNED_SIZE);
+        auto p = raw_data;
+        filesize = ((size_t*)raw_data)[0];
+        p += sizeof(filesize);
+        source = std::string_view(p, strlen(p));
+        p += source.size() + 1;
+        etag = std::string_view(p, strlen(p));
+        p += etag.size() + 1;
+        mount_path = std::string_view(p, strlen(p));
+        LOG_DEBUG("parse target object. {source:` , mount: `, size: `, etag: `}", source, mount_path, filesize, etag);
+    }
+
+    estring remote_url() const {
+        estring url;
+        url.append("https://");
+        url.append(bucket_name);
+        url.append(".");
+        url.append(endpoint);
+        url.append(source);
+        LOG_DEBUG("remote url: `", url);
+        return url;
+    }
+};
+
 class IReferenceList {
 public:
     virtual photon::fs::IFile* get_remote_target(off_t target_index = -1) = 0;
-    virtual ~IReferenceList();
+
+    virtual int stat_object(off_t idx, ELinkObject *stat) = 0;
+
+
+    // virtual int create_reference_object(char *out, std::string_view src, std::string_view mountpath, 
+    //     ssize_t object_size, std::string_view etag) = 0;
+
+    // return the reference index of the new object
+    virtual off_t append_elink_object(std::string_view src, std::string_view mountpath, 
+        ssize_t object_size, std::string_view etag) = 0;
+
+    virtual ~IReferenceList(){};
 };
 
-IReferenceList *create_reference_list(photon::fs::IFile* file, std::string_view bucket_name, IAuthPlugin *auth);
+IReferenceList *create_raw_reference_list(photon::fs::IFile* file, std::string_view bucket_name, std::string_view endpoint, IAuthPlugin *auth);
 
 ICredentialClient *create_simple_cred_client(const char *fn);
 IAuthPlugin *create_auth_plugin(ICredentialClient *cred, AuthPluginType type);
 
-photon::fs::IFile *open_elink_file(IReferenceList *reflist);
+photon::fs::IFile *open_elink_file(IReferenceList *reflist, bool ownership = false);
+
+int create_elink(photon::fs::IFileSystem *fs, IReferenceList *reflist, off_t ref_idx);
 
 }

--- a/src/overlaybd/elink/elink_file.cpp
+++ b/src/overlaybd/elink/elink_file.cpp
@@ -1,0 +1,63 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "def.h"
+#include "photon/common/alog.h"
+#include "photon/fs/filesystem.h"
+#include "../lsmt/index.h"
+#include "photon/fs/virtual-file.h"
+#include <errno.h>
+
+using namespace photon::fs;
+using namespace std;
+
+namespace ELink{
+
+class ELinkFile : public photon::fs::VirtualReadOnlyFile
+{
+public:
+    IReferenceList *m_reflist = nullptr;
+    // unordered_map<off_t, IFile*> m_files;
+
+    ELinkFile(IReferenceList *reflist) : m_reflist(reflist){};
+
+    virtual ssize_t pread(void *buf, size_t count, off_t offset) override {
+
+        LSMT::SegmentMapping m {
+            offset / ALIGNMENT_4K, 
+            (uint32_t)(count / ALIGNMENT_4K),
+            0, 0
+        };
+        off_t ref_idx = m.reference_index();
+        off_t inner_offset = m.inner_offest();
+        assert(ref_idx>=0);
+        auto file = m_reflist->get_remote_target(ref_idx);
+        if (file == nullptr) {
+            LOG_ERRNO_RETURN(EACCES, -1, "failed to get remote file");
+        }
+        return file->pread(buf, count, inner_offset);
+    };
+
+    UNIMPLEMENTED_POINTER(IFileSystem* filesystem() override);
+    UNIMPLEMENTED(int fstat(struct stat *st) override);
+
+};
+
+photon::fs::IFile *open_elink_file(IReferenceList *reflist) {
+
+    return new ELinkFile(reflist);
+}
+}

--- a/src/overlaybd/elink/elink_file.cpp
+++ b/src/overlaybd/elink/elink_file.cpp
@@ -15,10 +15,15 @@
 */
 
 #include "def.h"
+#include "elink.h"
 #include "photon/common/alog.h"
 #include "photon/fs/filesystem.h"
+#include <sys/types.h>
+#include <sys/fcntl.h>
+#include "../lsmt/file.h"
 #include "../lsmt/index.h"
 #include "photon/fs/virtual-file.h"
+#include <photon/fs/fiemap.h>
 #include <errno.h>
 
 using namespace photon::fs;
@@ -30,25 +35,44 @@ class ELinkFile : public photon::fs::VirtualReadOnlyFile
 {
 public:
     IReferenceList *m_reflist = nullptr;
+    bool m_ownership = false;
     // unordered_map<off_t, IFile*> m_files;
 
-    ELinkFile(IReferenceList *reflist) : m_reflist(reflist){};
+    ELinkFile(IReferenceList *reflist, bool ownership) : m_reflist(reflist), m_ownership(ownership) {};
+
+    virtual ~ELinkFile() {
+        if (m_ownership) {
+            delete m_reflist;
+        }
+    }
 
     virtual ssize_t pread(void *buf, size_t count, off_t offset) override {
 
-        LSMT::SegmentMapping m {
-            offset / ALIGNMENT_4K, 
-            (uint32_t)(count / ALIGNMENT_4K),
-            0, 0
+        LSMT::SegmentMapping m{
+            0, 0,
+            (uint64_t)offset / LSMT::ALIGNMENT, 
+            0
         };
         off_t ref_idx = m.reference_index();
         off_t inner_offset = m.inner_offest();
         assert(ref_idx>=0);
+        LOG_DEBUG("read from elink object {ref_idx: `, offset: `}", ref_idx, inner_offset);
         auto file = m_reflist->get_remote_target(ref_idx);
         if (file == nullptr) {
             LOG_ERRNO_RETURN(EACCES, -1, "failed to get remote file");
         }
-        return file->pread(buf, count, inner_offset);
+        ssize_t readn = file->pread(buf, count, inner_offset * LSMT::ALIGNMENT);
+        if (readn < (ssize_t)count) {
+            // check end of file
+            struct stat st;
+            file->fstat(&st);
+            if (inner_offset * LSMT::ALIGNMENT + count < (size_t)st.st_size) {
+                LOG_ERRNO_RETURN(0, -1, "failed to read remote file (offset: `, count: `,  actual read: `)", offset, count, readn);
+            }
+            // fill zero
+            memset((char*)buf + readn, 0, count - readn);
+        }
+        return count;
     };
 
     UNIMPLEMENTED_POINTER(IFileSystem* filesystem() override);
@@ -56,8 +80,47 @@ public:
 
 };
 
-photon::fs::IFile *open_elink_file(IReferenceList *reflist) {
+photon::fs::IFile *open_elink_file(IReferenceList *reflist, bool ownership) {
 
-    return new ELinkFile(reflist);
+    return new ELinkFile(reflist, ownership);
 }
+
+int create_elink(photon::fs::IFileSystem *fs, IReferenceList *reflist, off_t ref_idx) {
+
+    ELinkObject target;
+    if (reflist->stat_object(ref_idx, &target) != 0) {
+        LOG_ERRNO_RETURN(EINVAL, -1, "failed to stat object");
+    }
+    auto fn = target.mount_path[0] != '/' ? estring("/") + target.mount_path : target.mount_path;
+    //TODO mkdir -p dirname(fn)
+    auto elink_obj = fs->open(fn.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0666);
+    if (elink_obj == nullptr) {
+        LOG_ERRNO_RETURN(EINVAL, -1, "failed to create elink object in FS");
+    }
+
+    struct photon::fs::fiemap_t<8192> fie(0, target.filesize);
+
+    if (elink_obj->fallocate(0, 0, target.filesize) != 0 || elink_obj->fiemap(&fie)!=0 ){
+        return -1;
+    }
+    auto imgfile = (IFile*)(fs->get_underlay_object());
+    assert(imgfile != nullptr);
+    off_t inner_offset = 0;
+    auto count = ((target.filesize + ALIGNMENT_BLK - 1) / ALIGNMENT_BLK) * ALIGNMENT_BLK;
+    for (uint32_t i = 0; i < fie.fm_mapped_extents; i++) {
+        LSMT::ELinkMapping lba;
+        lba.offset = fie.fm_extents[i].fe_physical;
+        lba.count = (fie.fm_extents[i].fe_length < count ? fie.fm_extents[i].fe_length : count);
+        lba.ref_idx = ref_idx;
+        lba.inner_offset = inner_offset;
+        int nwrite = imgfile->ioctl(LSMT::IFileRW::ELinkData, lba);
+        if (nwrite < 0) {
+            LOG_ERRNO_RETURN(0, -1, "failed to write lba");
+        }
+        inner_offset += nwrite;
+        count-=lba.count;
+    }
+    return 0;
+}
+
 }

--- a/src/overlaybd/elink/oss_auth.cpp
+++ b/src/overlaybd/elink/oss_auth.cpp
@@ -20,6 +20,7 @@
 #include "photon/fs/filesystem.h"
 #include "yaml-cpp/node/node.h"
 
+#include <cerrno>
 #include <fcntl.h>
 #include <openssl/hmac.h>
 #include <openssl/md5.h>
@@ -100,13 +101,19 @@ public:
         return std::string((const char *)output, output_length);
     }
 
-    void reload_access_key(std::string_view url) {
+    int reload_access_key(std::string_view url) {
+        if (m_client == nullptr) {
+            access_key_id = "";
+            access_key_secret = "";
+            return -ENOENT;
+        }
         auto r = m_client->access_key(url);
         access_key_id = r["access_key_id"];
         access_key_secret = r["access_key_secret"];
+        return 0;
     }
 
-    virtual IFile* get_signed_object(const TargetObject &target) override {
+    virtual IFile* get_signed_object(const ELinkObject &target) override {
         char m_gmt_date[64]{};
         time_t t = photon::now / 1000 / 1000;
         struct tm *p = gmtime(&t);
@@ -115,25 +122,30 @@ public:
         std::string sig;
         /* /dadi-shared.oss-cn-beijing.aliyuncs.com/k8s.gcr.io-pause-3.5.tar.gz */
         auto data = estring().appends("GET", "\n", "\n", "\n", m_gmt_date, "\n", "/",
-                                    target.m_bucket_name, target.source, "");
+                                    target.bucket_name, target.source, "");
 
         LOG_INFO(VALUE(data));
-        if (access_key_id.empty()) {
-            reload_access_key(target.remote_url());
-        }
-        LOG_DEBUG("acess_key_id: `, access_key_secret: `", access_key_id, access_key_secret);
-        photon::net::Base64Encode(hmac_sha1(access_key_secret, data), sig);
-        LOG_INFO(VALUE(m_gmt_date));
-        auto a = estring().appends("OSS ", access_key_id, ":", sig);
-
         auto url = target.remote_url();
         auto remotefile = m_fs->open(url.c_str(), O_RDONLY);
         if (remotefile == nullptr) {
             LOG_ERRNO_RETURN(0, nullptr, "open remote file failed");
         }
-        remotefile->ioctl(HTTP_HEADER, "Date", m_gmt_date);
-        remotefile->ioctl(HTTP_HEADER, "Authorization", a.c_str());
-        LOG_DEBUG("open remote object with headers [{Date: `}, {Authorization: `}]", m_gmt_date, a);
+        if (access_key_id.empty()) {
+            reload_access_key(target.remote_url());
+        }
+        LOG_DEBUG("acess_key_id: '`', access_key_secret: '`'", access_key_id, access_key_secret);
+        if (!access_key_id.empty()){
+            photon::net::Base64Encode(hmac_sha1(access_key_secret, data), sig);
+            LOG_INFO(VALUE(m_gmt_date));
+            auto a = estring().appends("OSS ", access_key_id, ":", sig);
+
+        
+            remotefile->ioctl(HTTP_HEADER, "Date", m_gmt_date);
+            remotefile->ioctl(HTTP_HEADER, "Authorization", a.c_str());
+            LOG_DEBUG("open remote object with headers [{Date: `}, {Authorization: `}]", m_gmt_date, a);
+        } else {
+            LOG_WARN("empty accessKey get, will try to access remote object with public permission.");
+        }
         // todo ETAG check
         struct stat st;
         if (remotefile->fstat(&st) != 0) {

--- a/src/overlaybd/elink/oss_auth.cpp
+++ b/src/overlaybd/elink/oss_auth.cpp
@@ -1,0 +1,171 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "def.h"
+#include "config.h"
+#include "photon/common/alog.h"
+#include "photon/fs/filesystem.h"
+#include "yaml-cpp/node/node.h"
+
+#include <fcntl.h>
+#include <openssl/hmac.h>
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+#include <photon/photon.h>
+#include <photon/thread/timer.h>
+#include <photon/net/utils.h>
+#include <photon/net/http/client.h>
+#include <photon/net/http/message.h>
+#include <photon/fs/httpfs/httpfs.h>
+#include <unordered_map>
+
+using namespace photon::net::http;
+using namespace photon::fs;
+
+namespace ELink{
+
+class OSSSimpleCredentialClient : public ICredentialClient {
+public:
+
+    App::OssCredential c;
+    OSSSimpleCredentialClient(const char *fn){
+        auto node = YAML::LoadFile(fn);
+        c = App::mergeConfig(c, node);
+    }
+
+    ~OSSSimpleCredentialClient(){}
+    virtual std::unordered_map<estring, estring> access_key(std::string_view url) override {
+        // TODO: maybe it needs to return different accessKey by 'url'
+        std::unordered_map<estring, estring> ret;
+        ret["access_key_id"] = c.accessKeyID();
+        ret["access_key_secret"] = c.accessKeySecret();
+        return ret;
+    }
+};
+
+
+class OSSAuthPlugin : public ELink::IAuthPlugin 
+{
+public:
+
+    IFileSystem *m_fs = nullptr; //httpfs
+
+    ICredentialClient *m_client = nullptr;
+    estring access_key_id;
+    estring access_key_secret;
+
+    OSSAuthPlugin(ICredentialClient *client) : m_client(client) {
+        m_fs = new_httpfs_v2();
+    }
+
+    ~OSSAuthPlugin() {
+        if (m_fs) {
+            delete m_fs;
+        }
+    }
+    std::string hmac_sha1(std::string_view key, std::string_view data) {
+        unsigned char output[EVP_MAX_MD_SIZE];
+        unsigned int output_length;
+
+    #if !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L
+        HMAC_CTX ctx;
+        auto evp_md = EVP_sha1();
+        HMAC_CTX_init(&ctx);
+        HMAC_Init_ex(&ctx, (const unsigned char *)key.data(), key.length(), evp_md, nullptr);
+        HMAC_Update(&ctx, (const unsigned char *)data.data(), data.length());
+        HMAC_Final(&ctx, (unsigned char *)output, &output_length);
+        HMAC_CTX_cleanup(&ctx);
+    #else
+        HMAC_CTX *ctx = HMAC_CTX_new();
+        auto evp_md = EVP_sha1();
+        HMAC_CTX_reset(ctx);
+        HMAC_Init_ex(ctx, (const unsigned char *)key.data(), key.length(), evp_md, nullptr);
+        HMAC_Update(ctx, (const unsigned char *)data.data(), data.length());
+        HMAC_Final(ctx, (unsigned char *)output, &output_length);
+        HMAC_CTX_free(ctx);
+    #endif
+        return std::string((const char *)output, output_length);
+    }
+
+    void reload_access_key(std::string_view url) {
+        auto r = m_client->access_key(url);
+        access_key_id = r["access_key_id"];
+        access_key_secret = r["access_key_secret"];
+    }
+
+    virtual IFile* get_signed_object(const TargetObject &target) override {
+        char m_gmt_date[64]{};
+        time_t t = photon::now / 1000 / 1000;
+        struct tm *p = gmtime(&t);
+        strftime(m_gmt_date, 64, "%a, %d %b %Y %H:%M:%S %Z", p);
+
+        std::string sig;
+        /* /dadi-shared.oss-cn-beijing.aliyuncs.com/k8s.gcr.io-pause-3.5.tar.gz */
+        auto data = estring().appends("GET", "\n", "\n", "\n", m_gmt_date, "\n", "/",
+                                    target.m_bucket_name, target.source, "");
+
+        LOG_INFO(VALUE(data));
+        if (access_key_id.empty()) {
+            reload_access_key(target.remote_url());
+        }
+        LOG_DEBUG("acess_key_id: `, access_key_secret: `", access_key_id, access_key_secret);
+        photon::net::Base64Encode(hmac_sha1(access_key_secret, data), sig);
+        LOG_INFO(VALUE(m_gmt_date));
+        auto a = estring().appends("OSS ", access_key_id, ":", sig);
+
+        auto url = target.remote_url();
+        auto remotefile = m_fs->open(url.c_str(), O_RDONLY);
+        if (remotefile == nullptr) {
+            LOG_ERRNO_RETURN(0, nullptr, "open remote file failed");
+        }
+        remotefile->ioctl(HTTP_HEADER, "Date", m_gmt_date);
+        remotefile->ioctl(HTTP_HEADER, "Authorization", a.c_str());
+        LOG_DEBUG("open remote object with headers [{Date: `}, {Authorization: `}]", m_gmt_date, a);
+        // todo ETAG check
+        struct stat st;
+        if (remotefile->fstat(&st) != 0) {
+            delete remotefile;
+            LOG_ERRNO_RETURN(0, nullptr, "fstat remote target failed {path `}", target.source);
+        }
+        if ((size_t)st.st_size != target.filesize) {
+            delete remotefile;
+            LOG_ERRNO_RETURN(0, nullptr, "unexpected object size get {path `, size: `(!=`)}", target.source, st.st_size, target.filesize);
+        }
+        return remotefile;
+    }
+
+};
+
+IAuthPlugin *create_auth_plugin(ICredentialClient *client, AuthPluginType type) {
+
+    IAuthPlugin *ret = nullptr;
+    switch (type) {
+        case AuthPluginType::AliyunOSS:
+            ret = new OSSAuthPlugin(client);
+            return ret;
+        default:
+            LOG_ERRNO_RETURN(0, nullptr, "Unsupported auth type");
+    }
+    return nullptr;
+}
+
+ICredentialClient *create_simple_cred_client(const char *fn) {
+    return new OSSSimpleCredentialClient(fn);
+}
+
+
+}
+

--- a/src/overlaybd/elink/reference_list.cpp
+++ b/src/overlaybd/elink/reference_list.cpp
@@ -1,0 +1,66 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "photon/common/alog-stdstring.h"
+#include "photon/common/alog.h"
+#include "photon/common/estring.h"
+#include <cstddef>
+#include <string_view>
+#include <unordered_map>
+#include "def.h"
+
+using namespace std;
+using namespace photon::fs;
+
+namespace ELink {
+
+class RawReferenceList : public IReferenceList {
+public:
+    /* FileFormat */
+    // | filesize | sourcePath + '\0' | eTag + '\0'  | mountPath + '\0' |
+    // | 8 bytes  | - bytes           | 32 + 1 bytes | - bytes          |
+
+    photon::fs::IFile *m_file = nullptr;
+
+    string m_endpoint;
+    string m_bucket_name;
+    IAuthPlugin *m_auth = nullptr;
+
+    // todo expire time?
+    unordered_map<off_t, IFile*> filepool;
+
+    RawReferenceList(photon::fs::IFile *file, string_view bucket_name, IAuthPlugin *auth): 
+        m_file(file), m_bucket_name(bucket_name), m_auth(auth)
+    {}
+
+    virtual photon::fs::IFile* get_remote_target(off_t target_index = -1) override {
+        
+        assert(target_index >= 0);
+        if (filepool.find(target_index) != filepool.end()) {
+            LOG_DEBUG("return opened file.");
+            return filepool[target_index];
+        }
+        off_t offset = target_index * RAW_ALIGNED_SIZE;
+        char buf[RAW_ALIGNED_SIZE];
+        if (m_file->pread(buf, RAW_ALIGNED_SIZE, offset) != RAW_ALIGNED_SIZE) {
+            LOG_ERRNO_RETURN(0, nullptr, "read reference list failed, idx: ` offset: `", target_index, offset);
+        }
+        auto targetObject = TargetObject(m_endpoint, m_bucket_name, buf, RAW_ALIGNED_SIZE);
+        return m_auth->get_signed_object(targetObject);
+        
+    }
+};
+}

--- a/src/overlaybd/elink/reference_list.cpp
+++ b/src/overlaybd/elink/reference_list.cpp
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+#include "elink.h"
 #include "photon/common/alog-stdstring.h"
 #include "photon/common/alog.h"
 #include "photon/common/estring.h"
@@ -31,19 +32,20 @@ class RawReferenceList : public IReferenceList {
 public:
     /* FileFormat */
     // | filesize | sourcePath + '\0' | eTag + '\0'  | mountPath + '\0' |
-    // | 8 bytes  | - bytes           | 32 + 1 bytes | - bytes          |
+    // | 8 bytes  | N + 1 bytes       | N + 1 bytes  | N +1 bytes       |
+    // need auto extend for object > 2TiB since ELinkMapping only supports object length no more than 2T
 
     photon::fs::IFile *m_file = nullptr;
 
-    string m_endpoint;
     string m_bucket_name;
+    string m_endpoint;
     IAuthPlugin *m_auth = nullptr;
 
     // todo expire time?
     unordered_map<off_t, IFile*> filepool;
 
-    RawReferenceList(photon::fs::IFile *file, string_view bucket_name, IAuthPlugin *auth): 
-        m_file(file), m_bucket_name(bucket_name), m_auth(auth)
+    RawReferenceList(photon::fs::IFile *file, string_view bucket_name, string_view endpoint, IAuthPlugin *auth): 
+        m_file(file), m_bucket_name(bucket_name), m_endpoint(endpoint), m_auth(auth)
     {}
 
     virtual photon::fs::IFile* get_remote_target(off_t target_index = -1) override {
@@ -58,9 +60,58 @@ public:
         if (m_file->pread(buf, RAW_ALIGNED_SIZE, offset) != RAW_ALIGNED_SIZE) {
             LOG_ERRNO_RETURN(0, nullptr, "read reference list failed, idx: ` offset: `", target_index, offset);
         }
-        auto targetObject = TargetObject(m_endpoint, m_bucket_name, buf, RAW_ALIGNED_SIZE);
-        return m_auth->get_signed_object(targetObject);
-        
+        auto targetObject = ELinkObject(m_endpoint, m_bucket_name, buf, RAW_ALIGNED_SIZE);
+        auto r = m_auth->get_signed_object(targetObject);      
+        if (r == nullptr) {
+            LOG_ERRNO_RETURN(0, nullptr, "get remote object failed");
+        }
+        filepool[target_index] = r;
+        return r;
+    }
+
+    virtual int stat_object(off_t idx, ELinkObject *stat) override {
+        off_t offset = idx * RAW_ALIGNED_SIZE;
+        char buf[RAW_ALIGNED_SIZE];
+        if (m_file->pread(buf, RAW_ALIGNED_SIZE, offset) != RAW_ALIGNED_SIZE) {
+            LOG_ERRNO_RETURN(0, -1, "read reference list failed, idx: ` offset: `", idx, offset);
+        }
+        *stat = ELinkObject(m_endpoint, m_bucket_name, buf, RAW_ALIGNED_SIZE);
+        return 0;
+    }
+
+    virtual off_t append_elink_object(std::string_view src, std::string_view mountpath, 
+        ssize_t object_size, std::string_view etag) override 
+    {
+        char *data = new char[RAW_ALIGNED_SIZE]{};
+        DEFER(delete []data);
+        auto p = data;
+        ((ssize_t*)p)[0] = object_size;
+        p+= sizeof(ssize_t);
+        if (src[0]!='/') {
+            *p='/';
+            p++;
+        }
+        memcpy(p, src.data(), src.size());
+        p+= src.size() + 1;
+        if (!etag.empty()) {
+            memcpy(p, etag.data(), etag.size());
+            p+= etag.size() + 1;
+        }
+        memcpy(p, mountpath.data(), mountpath.size());
+        auto offset = m_file->lseek(0, SEEK_END);
+        if (m_file->pwrite(data, RAW_ALIGNED_SIZE, offset) != RAW_ALIGNED_SIZE) {
+            LOG_ERRNO_RETURN(0, -1, "append reference object failed");
+        }
+        auto id = offset / RAW_ALIGNED_SIZE;
+        LOG_DEBUG("append elink object success. idx: `, src: `, etag: `", id, src, etag);
+        return id;
     }
 };
+
+IReferenceList *create_raw_reference_list(photon::fs::IFile* file, std::string_view bucket_name, std::string_view endpoint, IAuthPlugin *auth) {
+
+    LOG_INFO("create raw reference list. using bucket name: `, endpoint: `", bucket_name, endpoint);
+    return new RawReferenceList(file, bucket_name, endpoint, auth);
+}
+
 }

--- a/src/overlaybd/elink/test/CMakeLists.txt
+++ b/src/overlaybd/elink/test/CMakeLists.txt
@@ -1,0 +1,21 @@
+include_directories($ENV{GFLAGS}/include)
+link_directories($ENV{GFLAGS}/lib)
+
+include_directories($ENV{GTEST}/googletest/include)
+link_directories($ENV{GTEST}/lib)
+
+add_executable(elink_test test.cpp ../../../tools/sha256file.cpp)
+target_include_directories(elink_test PUBLIC ${PHOTON_INCLUDE_DIR})
+target_link_libraries(elink_test 
+    photon_static
+    yaml-cpp
+    gtest gtest_main gflags 
+    pthread
+    elink_lib
+)
+
+add_test(
+  NAME elink_test
+  COMMAND ${EXECUTABLE_OUTPUT_PATH}/elink_test
+)
+

--- a/src/overlaybd/elink/test/CMakeLists.txt
+++ b/src/overlaybd/elink/test/CMakeLists.txt
@@ -4,7 +4,7 @@ link_directories($ENV{GFLAGS}/lib)
 include_directories($ENV{GTEST}/googletest/include)
 link_directories($ENV{GTEST}/lib)
 
-add_executable(elink_test test.cpp ../../../tools/sha256file.cpp)
+add_executable(elink_test test.cpp func.cpp ../../../tools/sha256file.cpp)
 target_include_directories(elink_test PUBLIC ${PHOTON_INCLUDE_DIR})
 target_link_libraries(elink_test 
     photon_static
@@ -12,6 +12,7 @@ target_link_libraries(elink_test
     gtest gtest_main gflags 
     pthread
     elink_lib
+    lsmt_lib
 )
 
 add_test(

--- a/src/overlaybd/elink/test/func.cpp
+++ b/src/overlaybd/elink/test/func.cpp
@@ -1,0 +1,154 @@
+
+
+#include <photon/photon.h>
+#include <photon/common/io-alloc.h>
+#include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/fs/localfs.h>
+#include <photon/io/fd-events.h>
+#include <photon/net/socket.h>
+#include <photon/thread/thread11.h>
+#include <gtest/gtest.h>
+#include <gflags/gflags.h>
+#include <iostream>
+#include <fcntl.h>
+#include <unistd.h>
+#include <zlib.h>
+#include <vector>
+#include <string.h>
+#include <photon/fs/subfs.h>
+#include "../def.h"
+#include "../../../tools/sha256file.h"
+#include "../../lsmt/file.h"
+#include <photon/fs/subfs.h>
+#include <photon/fs/extfs/extfs.h>
+
+
+using namespace std;
+using namespace photon::fs;
+
+#define FILE_SIZE (2 * 1024 * 1024)
+#define IMAGE_SIZE 512UL<<20
+class ELinkTest : public ::testing::Test {
+protected:
+    virtual void SetUp() override{
+        fs = photon::fs::new_localfs_adaptor();
+
+        ASSERT_NE(nullptr, fs);
+        if (fs->access(workdir.c_str(), 0) != 0) {
+            auto ret = fs->mkdir(workdir.c_str(), 0755);
+            ASSERT_EQ(0, ret);
+        }
+
+        fs = photon::fs::new_subfs(fs, workdir.c_str(), true);
+        ASSERT_NE(nullptr, fs);
+    }
+    virtual void TearDown() override{
+        for (auto fn : filelist){
+            fs->unlink(fn.c_str());
+        }
+        if (fs)
+            delete fs;
+    }
+
+    int download(const std::string &url, std::string out = "") {
+        if (out == "") {
+            out = workdir + "/" + std::string(basename(url.c_str()));
+        }
+        if (fs->access(out.c_str(), 0) == 0)
+            return 0;
+        // download file
+        std::string cmd = "curl -s -o " + out + " " + url;
+        LOG_INFO(VALUE(cmd.c_str()));
+        auto ret = system(cmd.c_str());
+        if (ret != 0) {
+            LOG_ERRNO_RETURN(0, -1, "download failed: `", url.c_str());
+        }
+        return 0;
+    }
+
+    int download_decomp(const std::string &url) {
+        // download file
+        std::string cmd = "wget -q -O - " + url +" | gzip -d -c >" +
+                          workdir + "/latest.tar";
+        LOG_INFO(VALUE(cmd.c_str()));
+        auto ret = system(cmd.c_str());
+        if (ret != 0) {
+            LOG_ERRNO_RETURN(0, -1, "download failed: `", url.c_str());
+        }
+        return 0;
+    }
+
+
+    int write_file(photon::fs::IFile *file) {
+        std::string bb = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01";
+        ssize_t size = 0;
+        ssize_t ret;
+        struct stat st;
+        LOG_INFO(VALUE(bb.size()));
+        while (size < FILE_SIZE) {
+            ret = file->write(bb.data(), bb.size());
+            EXPECT_EQ(bb.size(), ret);
+            ret = file->fstat(&st);
+            EXPECT_EQ(0, ret);
+            ret = file->lseek(0, SEEK_CUR);
+            EXPECT_EQ(st.st_size, ret);
+            size += bb.size();
+        }
+        LOG_INFO("write ` byte", size);
+        EXPECT_EQ(FILE_SIZE, size);
+        return 0;
+    }
+
+    IFile *createDevice(const char *fn, IFile *elinkfile, size_t virtual_size = IMAGE_SIZE){
+        auto fn_idx = std::string(fn)+".idx";
+        auto fn_meta = std::string(fn)+".meta";
+        DEFER({
+            filelist.push_back(fn_idx);
+            filelist.push_back(fn_meta);
+        });
+        auto fmeta = fs->open(fn_idx.c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IRWXU);
+        auto findex = fs->open(fn_meta.c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IRWXU);
+        LSMT::WarpFileArgs args(findex, fmeta, elinkfile);
+        args.virtual_size = virtual_size;
+        return create_warpfile(args, false);
+    }
+
+    int do_verify(IFile *verify, IFile *test, off_t offset = 0, ssize_t count = -1) {
+
+        if (count == -1) {
+            count = verify->lseek(0, SEEK_END);
+            auto len = test->lseek(0, SEEK_END);
+            if (count != len) {
+                LOG_ERROR("check logical length failed");
+                return -1;
+            }
+        }
+        LOG_INFO("start verify, virtual size: `", count);
+
+        ssize_t LEN = 1UL<<20;
+        char vbuf[1UL<<20], tbuf[1UL<<20];
+        // set_log_output_level(0);
+        for (off_t i = 0; i < count; i+=LEN) {
+            LOG_DEBUG("`", i);
+            auto ret_v = verify->pread(vbuf, LEN, i);
+            auto ret_t = test->pread(tbuf, LEN, i);
+            if (ret_v == -1 || ret_t == -1) {
+                LOG_ERROR_RETURN(0, -1, "pread(`,`) failed. (ret_v: `, ret_t: `)",
+                    i, LEN, ret_v, ret_v);
+            }
+            if (ret_v != ret_t) {
+                LOG_ERROR_RETURN(0, -1, "compare pread(`,`) return code failed. ret:` / `(expected)",
+                    i, LEN, ret_t, ret_v);
+            }
+            if (memcmp(vbuf, tbuf, ret_v)!= 0){
+                LOG_ERROR_RETURN(0, -1, "compare pread(`,`) buffer failed.", i, LEN);
+            }
+        }
+        return 0;
+    }
+
+    std::string workdir = "/tmp/elinktest";
+    photon::fs::IFileSystem *fs;
+    std::vector<std::string> filelist;
+};

--- a/src/overlaybd/elink/test/test.cpp
+++ b/src/overlaybd/elink/test/test.cpp
@@ -1,0 +1,144 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <photon/photon.h>
+#include <photon/common/io-alloc.h>
+#include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/fs/localfs.h>
+#include <photon/io/fd-events.h>
+#include <photon/net/socket.h>
+#include <photon/thread/thread11.h>
+#include <gtest/gtest.h>
+#include <gflags/gflags.h>
+#include <iostream>
+#include <fcntl.h>
+#include <unistd.h>
+#include <zlib.h>
+#include <vector>
+#include <string.h>
+#include "../def.h"
+#include "../../../tools/sha256file.h"
+
+using namespace std;
+
+DEFINE_int32(log_level, 0, "log level");
+DEFINE_string(ak, "", "accessKeyID");
+DEFINE_string(sk, "", "accessKeySecret");
+
+
+TEST(SimpleCredClient, parse) {
+    const string content = R"(
+    {
+        "accessKeyID": "accessKeyID000",
+        "accessKeySecret": "accessKeySecret111",
+    }
+    )";
+    auto lfs = photon::fs::new_localfs_adaptor();
+    EXPECT_NE(lfs, nullptr);
+    DEFER(delete lfs);
+    auto file = lfs->open("/tmp/test.cred", O_CREAT | O_TRUNC | O_RDWR, 0644);    EXPECT_NE(file, nullptr);
+    file->write(content.data(), content.size());
+    file->close();
+    delete file;
+    auto client = ELink::create_simple_cred_client("/tmp/test.cred");
+    EXPECT_NE(client, nullptr);
+    DEFER(delete client);
+    auto r = client->access_key("asdf");
+    for (auto item : r) {
+        LOG_INFO("key: ", item.first, ", value: ", item.second);
+    }
+}
+
+TEST(SimpleAuth, get_signed_url0) {
+    char buf[1024]{};
+    sprintf(buf, "{\"accessKeyID\": \"%s\", \"accessKeySecret\": \"%s\"}", FLAGS_ak.c_str(), FLAGS_sk.c_str());
+    auto lfs = photon::fs::new_localfs_adaptor();
+    EXPECT_NE(lfs, nullptr);
+    DEFER(delete lfs);
+    auto file = lfs->open("/tmp/test.cred", O_CREAT | O_TRUNC | O_RDWR, 0644);
+    EXPECT_NE(file, nullptr);
+    EXPECT_EQ(file->write(buf, strlen(buf)), strlen(buf));
+    delete file;
+    DEFER(lfs->unlink("/tmp/test.cred"));
+    auto cred = ELink::create_simple_cred_client("/tmp/test.cred");
+    DEFER(delete cred);
+    auto auth = ELink::create_auth_plugin(cred, ELink::AuthPluginType::AliyunOSS);
+    DEFER(delete auth);
+    char raw[ELink::RAW_ALIGNED_SIZE]{};
+    ((size_t*)raw)[0] = 2232023984;
+    auto objname = "/DADI_at_Scale_fix.mov";
+    memcpy(raw + sizeof(size_t), objname, strlen(objname));
+    auto etag = "BD221597AF09D219E63E7A83651A28F5-400";
+    memcpy(raw + sizeof(size_t) + strlen(objname) + 1, etag, strlen(etag)); 
+    ELink::TargetObject t("oss-cn-beijing.aliyuncs.com", "dadi-shared", raw, ELink::RAW_ALIGNED_SIZE);
+    EXPECT_STREQ(t.etag.data(), etag);
+    auto remote_file = auth->get_signed_object(t);
+    EXPECT_NE(remote_file, nullptr);
+    DEFER(delete remote_file);
+}
+
+
+TEST(SimpleAuth, get_signed_url1) {
+    if (FLAGS_ak.empty() || FLAGS_sk.empty()) {
+        LOG_INFO("this testcase needs --ak and --sk specified");
+        return;
+    }
+    char buf[1024]{};
+    sprintf(buf, "{\"accessKeyID\": \"%s\", \"accessKeySecret\": \"%s\"}", FLAGS_ak.c_str(), FLAGS_sk.c_str());
+    auto lfs = photon::fs::new_localfs_adaptor();
+    EXPECT_NE(lfs, nullptr);
+    DEFER(delete lfs);
+    auto file = lfs->open("/tmp/test.cred", O_CREAT | O_TRUNC | O_RDWR, 0644);
+    EXPECT_NE(file, nullptr);
+    EXPECT_EQ(file->write(buf, strlen(buf)), strlen(buf));
+    delete file;
+    DEFER(lfs->unlink("/tmp/test.cred"));
+    auto cred = ELink::create_simple_cred_client("/tmp/test.cred");
+    auto auth = ELink::create_auth_plugin(cred, ELink::AuthPluginType::AliyunOSS);
+    DEFER(delete auth);
+    char raw[ELink::RAW_ALIGNED_SIZE]{};
+    ((size_t*)raw)[0] = 754176;
+    auto objname = "/k8s.gcr.io-pause-3.5.tar.gz";
+    memcpy(raw + sizeof(size_t), objname, strlen(objname));
+    auto etag = "C4FDFB659D81309CE7C532B264E5BC7D";
+    memcpy(raw + sizeof(size_t) + strlen(objname) + 1, etag, strlen(etag)); 
+    ELink::TargetObject t("oss-cn-beijing.aliyuncs.com", "dadi-shared", raw, ELink::RAW_ALIGNED_SIZE);
+    EXPECT_STREQ(t.etag.data(), etag);
+    auto remote_file = auth->get_signed_object(t);
+    EXPECT_NE(remote_file, nullptr);
+    DEFER(delete remote_file);
+    auto sha256file = new_sha256_file(remote_file, false);
+    auto sha256checksum = sha256file->sha256_checksum();
+    EXPECT_STREQ(sha256checksum.c_str(), "sha256:2b7c3003b2aee057b4c0bd24be0ecec3f57d14074e9078feeda4c675e165cf43");
+    delete sha256file;
+}
+
+int main(int argc, char **argv) {
+    auto seed = 154574045;
+    std::cerr << "seed = " << seed << std::endl;
+    srand(seed);
+    set_log_output_level(1);
+
+    ::testing::InitGoogleTest(&argc, argv);
+    ::gflags::ParseCommandLineFlags(&argc, &argv, true);
+    log_output_level = FLAGS_log_level;
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    auto ret = RUN_ALL_TESTS();
+    photon::fini();
+    if (ret)
+        LOG_ERROR_RETURN(0, ret, VALUE(ret));
+}

--- a/src/overlaybd/elink/test/test.cpp
+++ b/src/overlaybd/elink/test/test.cpp
@@ -14,28 +14,12 @@
    limitations under the License.
 */
 
-#include <photon/photon.h>
-#include <photon/common/io-alloc.h>
-#include <photon/common/alog.h>
-#include <photon/common/alog-stdstring.h>
-#include <photon/fs/localfs.h>
-#include <photon/io/fd-events.h>
-#include <photon/net/socket.h>
-#include <photon/thread/thread11.h>
-#include <gtest/gtest.h>
-#include <gflags/gflags.h>
-#include <iostream>
+#include "func.cpp"
 #include <fcntl.h>
-#include <unistd.h>
-#include <zlib.h>
-#include <vector>
-#include <string.h>
-#include "../def.h"
-#include "../../../tools/sha256file.h"
+#include <gtest/gtest.h>
 
-using namespace std;
 
-DEFINE_int32(log_level, 0, "log level");
+DEFINE_int32(log_level, 1, "log level");
 DEFINE_string(ak, "", "accessKeyID");
 DEFINE_string(sk, "", "accessKeySecret");
 
@@ -84,7 +68,7 @@ TEST(SimpleAuth, get_signed_url0) {
     memcpy(raw + sizeof(size_t), objname, strlen(objname));
     auto etag = "BD221597AF09D219E63E7A83651A28F5-400";
     memcpy(raw + sizeof(size_t) + strlen(objname) + 1, etag, strlen(etag)); 
-    ELink::TargetObject t("oss-cn-beijing.aliyuncs.com", "dadi-shared", raw, ELink::RAW_ALIGNED_SIZE);
+    ELink::ELinkObject t("oss-cn-beijing.aliyuncs.com", "dadi-shared", raw, ELink::RAW_ALIGNED_SIZE);
     EXPECT_STREQ(t.etag.data(), etag);
     auto remote_file = auth->get_signed_object(t);
     EXPECT_NE(remote_file, nullptr);
@@ -116,7 +100,7 @@ TEST(SimpleAuth, get_signed_url1) {
     memcpy(raw + sizeof(size_t), objname, strlen(objname));
     auto etag = "C4FDFB659D81309CE7C532B264E5BC7D";
     memcpy(raw + sizeof(size_t) + strlen(objname) + 1, etag, strlen(etag)); 
-    ELink::TargetObject t("oss-cn-beijing.aliyuncs.com", "dadi-shared", raw, ELink::RAW_ALIGNED_SIZE);
+    ELink::ELinkObject t("oss-cn-beijing.aliyuncs.com", "dadi-shared", raw, ELink::RAW_ALIGNED_SIZE);
     EXPECT_STREQ(t.etag.data(), etag);
     auto remote_file = auth->get_signed_object(t);
     EXPECT_NE(remote_file, nullptr);
@@ -125,6 +109,91 @@ TEST(SimpleAuth, get_signed_url1) {
     auto sha256checksum = sha256file->sha256_checksum();
     EXPECT_STREQ(sha256checksum.c_str(), "sha256:2b7c3003b2aee057b4c0bd24be0ecec3f57d14074e9078feeda4c675e165cf43");
     delete sha256file;
+}
+
+
+TEST(Simple, elinkMapping) {
+    if (FLAGS_ak.empty() || FLAGS_sk.empty()) {
+        LOG_INFO("this testcase needs --ak and --sk specified");
+        return;
+    }
+    char buf[1024]{};
+    sprintf(buf, "{\"accessKeyID\": \"%s\", \"accessKeySecret\": \"%s\"}", FLAGS_ak.c_str(), FLAGS_sk.c_str());
+    auto lfs = photon::fs::new_localfs_adaptor();
+    EXPECT_NE(lfs, nullptr);
+    DEFER(delete lfs);
+    auto file = lfs->open("/tmp/test.cred", O_CREAT | O_TRUNC | O_RDWR, 0644);
+    EXPECT_NE(file, nullptr);
+    EXPECT_EQ(file->write(buf, strlen(buf)), strlen(buf));
+    delete file;
+    DEFER(lfs->unlink("/tmp/test.cred"));
+    auto cred = ELink::create_simple_cred_client("/tmp/test.cred");
+    auto auth = ELink::create_auth_plugin(cred, ELink::AuthPluginType::AliyunOSS);
+    DEFER(delete auth);
+    char raw[ELink::RAW_ALIGNED_SIZE]{};
+    ((size_t*)raw)[0] = 754176;
+    auto objname = "/k8s.gcr.io-pause-3.5.tar.gz";
+    memcpy(raw + sizeof(size_t), objname, strlen(objname));
+    auto etag = "C4FDFB659D81309CE7C532B264E5BC7D";
+    memcpy(raw + sizeof(size_t) + strlen(objname) + 1, etag, strlen(etag)); 
+    ELink::ELinkObject t("oss-cn-beijing.aliyuncs.com", "dadi-shared", raw, ELink::RAW_ALIGNED_SIZE);
+    EXPECT_STREQ(t.etag.data(), etag);
+    auto remote_file = auth->get_signed_object(t);
+    EXPECT_NE(remote_file, nullptr);
+    DEFER(delete remote_file);
+    auto sha256file = new_sha256_file(remote_file, false);
+    auto sha256checksum = sha256file->sha256_checksum();
+    EXPECT_STREQ(sha256checksum.c_str(), "sha256:2b7c3003b2aee057b4c0bd24be0ecec3f57d14074e9078feeda4c675e165cf43");
+    delete sha256file;
+}
+
+TEST_F(ELinkTest, create) {
+     if (FLAGS_ak.empty() || FLAGS_sk.empty()) {
+        LOG_INFO("this testcase needs --ak and --sk specified");
+        return;
+    }
+    char buf[1024]{};
+    sprintf(buf, "{\"accessKeyID\": \"%s\", \"accessKeySecret\": \"%s\"}", FLAGS_ak.c_str(), FLAGS_sk.c_str());
+    auto lfs = photon::fs::new_localfs_adaptor();
+    EXPECT_NE(lfs, nullptr);
+    DEFER(delete lfs);
+    auto file = lfs->open("/tmp/test.cred", O_CREAT | O_TRUNC | O_RDWR, 0644);
+    EXPECT_NE(file, nullptr);
+    EXPECT_EQ(file->write(buf, strlen(buf)), strlen(buf));
+    delete file;
+    DEFER(lfs->unlink("/tmp/test.cred"));
+    auto cred = ELink::create_simple_cred_client("/tmp/test.cred");
+    // set_log_output_level(0);
+
+    auto reflist_file = fs->open("ref.list", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    ASSERT_NE(reflist_file, nullptr);
+    auto auth = ELink::create_auth_plugin(cred, ELink::AuthPluginType::AliyunOSS);
+    DEFER(delete auth);
+    auto reflist = ELink::create_raw_reference_list(reflist_file, "elink-volume", "oss-ap-northeast-1-internal.aliyuncs.com", auth);
+    DEFER(delete reflist);
+    auto idx = reflist->append_elink_object("go1.21.13.linux-amd64.tar.gz", "/go1.21.13.linux-amd64.tar.gz", 
+        66660837, "3C624B8AC6980E79653F1AD478828F7C");
+    auto elinkfile = ELink::open_elink_file(reflist);
+    auto imgfile = createDevice("mock", elinkfile);
+    DEFER(delete imgfile;);
+    make_extfs(imgfile);
+    auto extfs = new_extfs(imgfile, false);
+    // auto target = new_subfs(extfs, "/", true);
+    // DEFER(delete target);
+    EXPECT_EQ(ELink::create_elink(extfs, reflist, idx), 0);
+    delete extfs;
+    extfs = new_extfs(imgfile, true);
+    DEFER(delete extfs);
+
+    auto remote_target = extfs->open("/go1.21.13.linux-amd64.tar.gz", O_RDONLY);
+    EXPECT_NE(remote_target, nullptr);
+    struct stat _;
+    EXPECT_EQ(remote_target->fstat(&_), 0);
+    EXPECT_EQ(_.st_size, 66660837);
+    auto sha256file = new_sha256_file(remote_target, true);
+    DEFER(delete sha256file);
+    auto sha256sum = sha256file->sha256_checksum();
+    EXPECT_STREQ(sha256sum.c_str(), "sha256:502fc16d5910562461e6a6631fb6377de2322aad7304bf2bcd23500ba9dab4a7");
 }
 
 int main(int argc, char **argv) {

--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -1143,32 +1143,59 @@ public:
         if (request == GetType) {
             return LSMTReadOnlyFile::vioctl(request, args);
         }
-        if (request != RemoteData) {
-            LOG_ERROR_RETURN(EINVAL, -1, "invaid request code");
+        if (request == RemoteData) {
+            va_list tmp;
+            va_copy(tmp, args);
+            auto lba = va_arg(tmp, RemoteMapping);
+            va_end(tmp);
+            LOG_DEBUG("RemoteMapping: {offset: `, count: `, roffset: `}", lba.offset, lba.count,
+                    lba.roffset);
+            size_t nwrite = 0;
+            while (lba.count > 0) {
+                SegmentMapping m;
+                m.offset = lba.offset / ALIGNMENT;
+                m.length = (Segment::MAX_LENGTH < lba.count / ALIGNMENT ? Segment::MAX_LENGTH
+                                                                        : lba.count / ALIGNMENT);
+                m.moffset = lba.roffset / ALIGNMENT;
+                m.tag = m_rw_tag + (uint8_t)SegmentType::remoteData;
+                LOG_DEBUG("insert segment: ` into findex: `", m, m_findex);
+                static_cast<IMemoryIndex0 *>(m_index)->insert(m);
+                append_index(m);
+                nwrite += m.length * ALIGNMENT;
+                lba.offset += m.length * ALIGNMENT;
+                lba.count -= m.length * ALIGNMENT;
+                lba.roffset += m.length * ALIGNMENT;
+            }
+            return nwrite;
         }
-        va_list tmp;
-        va_copy(tmp, args);
-        auto lba = va_arg(tmp, RemoteMapping);
-        va_end(tmp);
-        LOG_DEBUG("RemoteMapping: {offset: `, count: `, roffset: `}", lba.offset, lba.count,
-                  lba.roffset);
-        size_t nwrite = 0;
-        while (lba.count > 0) {
-            SegmentMapping m;
-            m.offset = lba.offset / ALIGNMENT;
-            m.length = (Segment::MAX_LENGTH < lba.count / ALIGNMENT ? Segment::MAX_LENGTH
-                                                                    : lba.count / ALIGNMENT);
-            m.moffset = lba.roffset / ALIGNMENT;
-            m.tag = m_rw_tag + (uint8_t)SegmentType::remoteData;
-            LOG_DEBUG("insert segment: ` into findex: `", m, m_findex);
-            static_cast<IMemoryIndex0 *>(m_index)->insert(m);
-            append_index(m);
-            nwrite += m.length * ALIGNMENT;
-            lba.offset += m.length * ALIGNMENT;
-            lba.count -= m.length * ALIGNMENT;
-            lba.roffset += m.length * ALIGNMENT;
+        if (request == ELinkData) {
+            va_list tmp;
+            va_copy(tmp, args);
+            auto lba = va_arg(tmp, ELinkMapping);
+            va_end(tmp);
+            LOG_DEBUG("ELinkMapping: {offset: `, count: `, targetIDX: `, inner_offset: `}", lba.offset, lba.count,
+                    lba.ref_idx, lba.inner_offset);
+            size_t nwrite = 0;
+            while (lba.count > 0) {
+                SegmentMapping m;
+                m.offset = lba.offset / ALIGNMENT;
+                m.length = (Segment::MAX_LENGTH < lba.count / ALIGNMENT ? Segment::MAX_LENGTH
+                                                                        : lba.count / ALIGNMENT);
+                m.set_elink_offset(lba.ref_idx, lba.inner_offset / ALIGNMENT);
+                m.tag = m_rw_tag + (uint8_t)SegmentType::remoteData;
+                LOG_DEBUG("insert elink segment: ` into findex: `", m, m_findex);
+                static_cast<IMemoryIndex0 *>(m_index)->insert(m);
+                append_index(m);
+                nwrite += m.length * ALIGNMENT;
+                lba.offset += m.length * ALIGNMENT;
+                lba.count -= m.length * ALIGNMENT;
+                lba.inner_offset += m.length * ALIGNMENT;
+            }
+            return nwrite;
         }
-        return nwrite;
+        
+        LOG_ERROR_RETURN(EINVAL, -1, "invaid request code");
+
     }
 
     size_t compact(CompactOptions &opts, size_t moffset, size_t &nindex) const {

--- a/src/overlaybd/lsmt/file.h
+++ b/src/overlaybd/lsmt/file.h
@@ -77,8 +77,9 @@ public:
     virtual IMemoryIndex0 *index() const override = 0;
     const int Index_Group_Commit = 10;
 
-    static const int RemoteData = 11;
-
+    static const int RemoteData = 11;  // for turboOCI
+    static const int ELinkData  = 13;  // for elink reference; 12 is GetType
+    
     int set_index_group_commit(size_t buffer_size) {
         return this->ioctl(Index_Group_Commit, buffer_size);
     }

--- a/src/overlaybd/lsmt/index.h
+++ b/src/overlaybd/lsmt/index.h
@@ -53,6 +53,8 @@ struct Segment {          // 48 + 18 == 64
 
 struct SegmentMapping : public Segment { // 64 + 55 + 9 == 128
     uint64_t moffset : 55;               // mapped offset (2^64 B if in sector)
+    // (4K align(12bit) + 32 bit) = 16T
+    //  24 bit = 16M items
     uint32_t zeroed : 1;                 // indicating a zero-filled segment
     uint8_t tag;
     const static uint64_t MAX_MOFFSET = (1UL << 55) - 1;
@@ -78,6 +80,15 @@ struct SegmentMapping : public Segment { // 64 + 55 + 9 == 128
     SegmentMapping &discard() {
         zeroed = 1;
         return *this;
+    }
+
+    // ELink: get internal offset of the target object
+    off_t inner_offest() {
+        return moffset >> 24;
+    }
+    // ELink: get target idx in referenceTable
+    off_t reference_index() {
+        return moffset & 0xffffff;
     }
     static SegmentMapping invalid_mapping() {
         return SegmentMapping(INVALID_OFFSET, 0, 0);

--- a/src/overlaybd/lsmt/index.h
+++ b/src/overlaybd/lsmt/index.h
@@ -34,6 +34,7 @@ struct Segment {          // 48 + 18 == 64
     uint32_t length : 14; // length (8MB if in sector)
     const static uint64_t MAX_OFFSET = (1UL << 50) - 1;
     const static uint32_t MAX_LENGTH = (1 << 14) - 1;
+
     const static uint64_t INVALID_OFFSET = MAX_OFFSET;
     uint64_t end() const {
         return offset + length;
@@ -53,7 +54,7 @@ struct Segment {          // 48 + 18 == 64
 
 struct SegmentMapping : public Segment { // 64 + 55 + 9 == 128
     uint64_t moffset : 55;               // mapped offset (2^64 B if in sector)
-    // (4K align(12bit) + 32 bit) = 16T
+    // (512B align(9bit) + 32 bit) = 2T
     //  24 bit = 16M items
     uint32_t zeroed : 1;                 // indicating a zero-filled segment
     uint8_t tag;
@@ -84,11 +85,15 @@ struct SegmentMapping : public Segment { // 64 + 55 + 9 == 128
 
     // ELink: get internal offset of the target object
     off_t inner_offest() {
-        return moffset >> 24;
+        return moffset & 0xffffffff;
     }
     // ELink: get target idx in referenceTable
     off_t reference_index() {
-        return moffset & 0xffffff;
+        return moffset >> 32;
+    }
+
+    void set_elink_offset(off_t ref_idx, off_t inner_offset) {
+        moffset = (ref_idx << 32) + inner_offset;
     }
     static SegmentMapping invalid_mapping() {
         return SegmentMapping(INVALID_OFFSET, 0, 0);
@@ -99,6 +104,13 @@ struct RemoteMapping {
     off_t offset;
     uint32_t count;
     off_t roffset;
+};
+
+struct ELinkMapping {
+    off_t offset;     // Logic offset in virtual device
+    uint32_t count;
+    off_t ref_idx;        // the index of target object in ReferenceList
+    off_t inner_offset;   // inner offset in the target object
 };
 
 enum class SegmentType {


### PR DESCRIPTION
   1. RawReferenceList Format: 
  ```
    | filesize | srcPath + '\0' | eTag + '\0'  | mountPath + '\0'|
    | 8 bytes  | N bytes        | 32 + 1 bytes | N bytes         |
```
   2. OSSAuthPlugin: authenticator of aliyunOSS with ak/sk

   3. ELinkFile: a dervied class of IFile which can access remote target via pread().

The I/O flow is:
```
     LSMTWarpFile::pread() --> ELinkFile::pread(offset, count)
        --> getReferenceList index of [offset, count)  --> remoteFile 
```

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
